### PR TITLE
added link to metro auto installer

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -48,6 +48,8 @@
       </div>
       <div class="sidebar">
         <a href="https://github.com/minischetti/metro-for-steam/archive/v4.4.zip" class="item important flash">Download</a>
+        <a href="https://github.com/henrikx/metroskininstaller/releases/latest/download/Metro.Skin.Updater.Tool.exe"
+        class="item important flash">Installer</a>
         <span class="item label">Connect</span>
         <a href="https://twitter.com/ThisIsDomDraper" target="_blank" class="item">
           <img class="icon" src="assets/twitter.svg"/>


### PR DESCRIPTION
It would be nice for the website to include a download button for the community made auto installer. 
With this installer you can choose either `Metro For steam` or  `Metro For Steam + Unofficial patch`